### PR TITLE
Bump Go to 1.27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shurshun/domain-harvester
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/bep/debounce v1.2.1


### PR DESCRIPTION
## Summary
- Bump the `go` directive in `go.mod` from 1.26.0 to 1.27.0.

`Dockerfile.local` is already on `golang:1.27-alpine`, and every CI workflow resolves the toolchain via `go-version-file: go.mod`, so this one-line change moves the whole pipeline to Go 1.27.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` — clean
- [x] `go test -race ./...` — all packages pass
- [ ] CI green
